### PR TITLE
タスク一覧画面の UI の調整

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,6 +7,7 @@ import { PageTaskComponent } from './page-task.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatButtonModule } from '@angular/material/button';
 import { LayoutComponent } from './layout.component';
+import { MatToolbarModule } from '@angular/material';
 
 @NgModule({
   declarations: [
@@ -18,7 +19,8 @@ import { LayoutComponent } from './layout.component';
     BrowserModule,
     AppRoutingModule,
     BrowserAnimationsModule,
-    MatButtonModule
+    MatButtonModule,
+    MatToolbarModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,7 +6,7 @@ import { AppComponent } from './app.component';
 import { PageTaskComponent } from './page-task.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LayoutComponent } from './layout.component';
-import { MatButtonModule, MatCardModule, MatIconModule, MatSliderModule, MatTableModule, MatToolbarModule } from '@angular/material';
+import { MatButtonModule, MatCardModule, MatIconModule, MatProgressBarModule, MatTableModule, MatToolbarModule } from '@angular/material';
 import { FormsModule } from '@angular/forms';
 
 @NgModule({
@@ -22,7 +22,7 @@ import { FormsModule } from '@angular/forms';
     MatButtonModule,
     MatCardModule,
     MatIconModule,
-    MatSliderModule,
+    MatProgressBarModule,
     MatTableModule,
     MatToolbarModule,
     FormsModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,11 +6,13 @@ import { AppComponent } from './app.component';
 import { PageTaskComponent } from './page-task.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatButtonModule } from '@angular/material/button';
+import { LayoutComponent } from './layout.component';
 
 @NgModule({
   declarations: [
     AppComponent,
-    PageTaskComponent
+    PageTaskComponent,
+    LayoutComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,9 +5,9 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { PageTaskComponent } from './page-task.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { MatButtonModule } from '@angular/material/button';
 import { LayoutComponent } from './layout.component';
-import { MatToolbarModule } from '@angular/material';
+import { MatButtonModule, MatCardModule, MatIconModule, MatSliderModule, MatTableModule, MatToolbarModule } from '@angular/material';
+import { FormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [
@@ -20,7 +20,12 @@ import { MatToolbarModule } from '@angular/material';
     AppRoutingModule,
     BrowserAnimationsModule,
     MatButtonModule,
+    MatCardModule,
+    MatIconModule,
+    MatSliderModule,
+    MatTableModule,
     MatToolbarModule,
+    FormsModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/layout.component.html
+++ b/src/app/layout.component.html
@@ -1,0 +1,1 @@
+<p>layout works!</p>

--- a/src/app/layout.component.html
+++ b/src/app/layout.component.html
@@ -1,1 +1,6 @@
-<p>layout works!</p>
+<header>
+  <mat-toolbar>Task Cabinet</mat-toolbar>
+</header>
+<main>
+  <ng-content></ng-content>
+</main>

--- a/src/app/layout.component.spec.ts
+++ b/src/app/layout.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LayoutComponent } from './layout.component';
+
+describe('LayoutComponent', () => {
+  let component: LayoutComponent;
+  let fixture: ComponentFixture<LayoutComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LayoutComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LayoutComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/layout.component.spec.ts
+++ b/src/app/layout.component.spec.ts
@@ -1,3 +1,4 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { LayoutComponent } from './layout.component';
@@ -8,7 +9,8 @@ describe('LayoutComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ LayoutComponent ]
+      declarations: [ LayoutComponent ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
     })
     .compileComponents();
   }));

--- a/src/app/layout.component.ts
+++ b/src/app/layout.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-layout',
+  templateUrl: './layout.component.html',
+  styleUrls: ['./layout.component.scss']
+})
+export class LayoutComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/page-task.component.html
+++ b/src/app/page-task.component.html
@@ -1,4 +1,23 @@
 <app-layout>
+  <mat-card *ngFor="let task of taskList">
+    <mat-card-title>{{task.name}}</mat-card-title>
+    <table>
+      <tbody>
+        <tr>
+          <th>期限</th>
+          <td>{{task.deadline}}</td>
+        </tr>
+        <tr>
+          <th>見積もり</th>
+          <td>
+            <mat-slider [(ngModel)]="task.estimate" min="1" max="100" disabled></mat-slider>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <button mat-button><mat-icon>done</mat-icon><span>完了</span></button>
+  </mat-card>
+
   <p>page-task works!</p>
   <button mat-button mat-raised-button color="primary">Primary Button!</button>
   <button mat-button mat-raised-button color="secondary">Secondary Button!</button>

--- a/src/app/page-task.component.html
+++ b/src/app/page-task.component.html
@@ -1,14 +1,16 @@
-<p>page-task works!</p>
-<button mat-button mat-raised-button color="primary">Primary Button!</button>
-<button mat-button mat-raised-button color="secondary">Secondary Button!</button>
+<app-layout>
+  <p>page-task works!</p>
+  <button mat-button mat-raised-button color="primary">Primary Button!</button>
+  <button mat-button mat-raised-button color="secondary">Secondary Button!</button>
 
-<ul>
-  <li *ngFor="let task of taskList">
-    <ul>
-      <li>id: {{task.id}}</li>
-      <li>name: {{task.name}}</li>
-      <li>deadline: {{task.deadline.toString()}}</li>
-      <li>estimate: {{task.estimate}}</li>
-    </ul>
-  </li>
-</ul>
+  <ul>
+    <li *ngFor="let task of taskList">
+      <ul>
+        <li>id: {{task.id}}</li>
+        <li>name: {{task.name}}</li>
+        <li>deadline: {{task.deadline.toString()}}</li>
+        <li>estimate: {{task.estimate}}</li>
+      </ul>
+    </li>
+  </ul>
+</app-layout>

--- a/src/app/page-task.component.html
+++ b/src/app/page-task.component.html
@@ -10,7 +10,7 @@
         <tr>
           <th>見積もり</th>
           <td>
-            <mat-slider [(ngModel)]="task.estimate" min="1" max="100" disabled></mat-slider>
+            <mat-progress-bar [value]="task.estimate"></mat-progress-bar>
           </td>
         </tr>
       </tbody>

--- a/src/app/page-task.component.html
+++ b/src/app/page-task.component.html
@@ -15,21 +15,14 @@
         </tr>
       </tbody>
     </table>
-    <button mat-button><mat-icon>done</mat-icon><span>完了</span></button>
+    <div class="done-button-wrapper">
+      <button mat-button>
+        <mat-icon>done</mat-icon>
+        <span>完了</span>
+      </button>
+    </div>
   </mat-card>
-
-  <p>page-task works!</p>
-  <button mat-button mat-raised-button color="primary">Primary Button!</button>
-  <button mat-button mat-raised-button color="secondary">Secondary Button!</button>
-
-  <ul>
-    <li *ngFor="let task of taskList">
-      <ul>
-        <li>id: {{task.id}}</li>
-        <li>name: {{task.name}}</li>
-        <li>deadline: {{task.deadline.toString()}}</li>
-        <li>estimate: {{task.estimate}}</li>
-      </ul>
-    </li>
-  </ul>
+  <button mat-fab class="add-button" aria-label="タスクを追加">
+    <mat-icon>add</mat-icon>
+  </button>
 </app-layout>

--- a/src/app/page-task.component.scss
+++ b/src/app/page-task.component.scss
@@ -5,3 +5,21 @@ mat-card {
 mat-icon + span {
   padding-left: 0.5rem;
 }
+
+mat-slider {
+  width: 100%;
+}
+
+table {
+  width: 100%;
+}
+
+.add-button {
+  bottom: 1rem;
+  position: fixed;
+  right: 1rem;
+}
+
+.done-button-wrapper {
+  text-align: right;
+}

--- a/src/app/page-task.component.scss
+++ b/src/app/page-task.component.scss
@@ -1,0 +1,7 @@
+mat-card {
+  margin: 0.5rem;
+}
+
+mat-icon + span {
+  padding-left: 0.5rem;
+}

--- a/src/app/page-task.component.spec.ts
+++ b/src/app/page-task.component.spec.ts
@@ -1,3 +1,4 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PageTaskComponent } from './page-task.component';
@@ -8,7 +9,8 @@ describe('PageTaskComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ PageTaskComponent ]
+      declarations: [ PageTaskComponent ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
     })
     .compileComponents();
   }));


### PR DESCRIPTION
Close #17 

タスク画面一覧の UI をつくりました。

`mat-slider` が `disabled` になっているのは、 `readonly` が見つからなかったからです :cry: 
あと、高さの調整ができてないです。。
（ `td` を `position: relative` にしたうえで、 `mat-slider` を `position: absolute` にし、
（ `top: -8px` とかにする、とかいう無理矢理なソリューションはありますが、やりたくない。

![image](https://user-images.githubusercontent.com/33417830/66883700-c3b06500-f009-11e9-9a0c-7048c1b28afc.png)
