### PR TITLE
gh-pages ブランチに対して CircleCI のテストが実行されないようにする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 version: 2
 jobs:
   build:
+    branches:
+      ignore: gh-pages
     working_directory: ~/repo
     docker:
       - image: circleci/node:10-browsers


### PR DESCRIPTION
gh-pages ブランチに対して CircleCI のテストが実行されないようにします。