### PR TITLE
「タスクの追加」コンポーネントに入力コンポーネントを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     "@angular/core": "~8.2.9",
     "@angular/forms": "~8.2.9",
     "@angular/material": "^8.2.3",
+    "@angular/material-moment-adapter": "^8.2.3",
     "@angular/platform-browser": "~8.2.9",
     "@angular/platform-browser-dynamic": "~8.2.9",
     "@angular/router": "~8.2.9",
     "angular-cli-ghpages": "^0.6.0",
     "hammerjs": "^2.0.8",
+    "moment": "^2.24.0",
     "rxjs": "~6.4.0",
     "tslib": "^1.10.0",
     "zone.js": "~0.9.1"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "moment": "^2.24.0",
     "rxjs": "~6.4.0",
     "tslib": "^1.10.0",
+    "uuid": "^3.3.3",
     "zone.js": "~0.9.1"
   },
   "devDependencies": {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,8 +6,20 @@ import { AppComponent } from './app.component';
 import { PageTaskComponent } from './page-task.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LayoutComponent } from './layout.component';
-import { MatButtonModule, MatCardModule, MatIconModule, MatProgressBarModule, MatTableModule, MatToolbarModule } from '@angular/material';
+import {
+  MatButtonModule,
+  MatCardModule,
+  MatIconModule,
+  MatProgressBarModule,
+  MatTableModule,
+  MatToolbarModule,
+  MatDatepickerModule,
+  MatFormFieldModule,
+  MatInputModule,
+  MatSliderModule
+} from '@angular/material';
 import { FormsModule } from '@angular/forms';
+import { MatMomentDateModule } from '@angular/material-moment-adapter';
 import { PageTaskAddComponent } from './page-task-add.component';
 
 @NgModule({
@@ -28,6 +40,11 @@ import { PageTaskAddComponent } from './page-task-add.component';
     MatTableModule,
     MatToolbarModule,
     FormsModule,
+    MatDatepickerModule,
+    MatMomentDateModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSliderModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,7 +16,7 @@ import {
   MatDatepickerModule,
   MatFormFieldModule,
   MatInputModule,
-  MatSliderModule
+  MatSliderModule,
 } from '@angular/material';
 import { FormsModule } from '@angular/forms';
 import { MatMomentDateModule } from '@angular/material-moment-adapter';

--- a/src/app/page-task-add.component.html
+++ b/src/app/page-task-add.component.html
@@ -1,16 +1,16 @@
 <app-layout>
   <div class="task-add-container">
     <mat-form-field>
-      <input matInput placeholder="タスク名">
+      <input matInput placeholder="タスク名" [(ngModel)]="task.name">
     </mat-form-field>
     <mat-form-field class="date-picker">
-      <input matInput [matDatepicker]="date" placeholder="タスクの期限">
+      <input matInput [matDatepicker]="date" [(ngModel)]="task.deadline" placeholder="タスクの期限">
       <mat-datepicker-toggle matSuffix [for]="date"></mat-datepicker-toggle>
       <mat-datepicker touchUi #date></mat-datepicker>
     </mat-form-field>
     <mat-label>見積り</mat-label>
     <mat-slider
-      [(value)]="task.estimate"
+      [(ngModel)]="task.estimate"
       thumbLabel
       min="1"
       max="5"

--- a/src/app/page-task-add.component.html
+++ b/src/app/page-task-add.component.html
@@ -1,1 +1,21 @@
-<p>page-task-add works!</p>
+<app-layout>
+  <div class="task-add-container">
+    <mat-form-field>
+      <input matInput placeholder="タスク名">
+    </mat-form-field>
+    <mat-form-field class="date-picker">
+      <input matInput [matDatepicker]="date" placeholder="タスクの期限">
+      <mat-datepicker-toggle matSuffix [for]="date"></mat-datepicker-toggle>
+      <mat-datepicker touchUi #date></mat-datepicker>
+    </mat-form-field>
+    <p>見積り</p>
+    <mat-slider
+      thumbLabel
+      min="1"
+      max="5"
+    ></mat-slider>
+    <button mat-button mat-raised-button color="accent" class="add-button" aria-label="タスクを追加">
+      タスクを追加
+    </button>
+  </div>
+</app-layout>

--- a/src/app/page-task-add.component.html
+++ b/src/app/page-task-add.component.html
@@ -8,7 +8,7 @@
       <mat-datepicker-toggle matSuffix [for]="date"></mat-datepicker-toggle>
       <mat-datepicker touchUi #date></mat-datepicker>
     </mat-form-field>
-    <p>見積り</p>
+    <mat-label>見積り</mat-label>
     <mat-slider
       thumbLabel
       min="1"

--- a/src/app/page-task-add.component.html
+++ b/src/app/page-task-add.component.html
@@ -10,6 +10,7 @@
     </mat-form-field>
     <mat-label>見積り</mat-label>
     <mat-slider
+      [(value)]="task.estimate"
       thumbLabel
       min="1"
       max="5"

--- a/src/app/page-task-add.component.scss
+++ b/src/app/page-task-add.component.scss
@@ -1,0 +1,5 @@
+.task-add-container {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+}

--- a/src/app/page-task-add.component.spec.ts
+++ b/src/app/page-task-add.component.spec.ts
@@ -1,5 +1,7 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDatepickerModule } from '@angular/material';
+import { MatMomentDateModule } from '@angular/material-moment-adapter';
 
 import { PageTaskAddComponent } from './page-task-add.component';
 
@@ -11,6 +13,7 @@ describe('PageTaskAddComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ PageTaskAddComponent ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
+      imports: [ MatDatepickerModule, MatMomentDateModule ],
     })
     .compileComponents();
   }));

--- a/src/app/page-task-add.component.spec.ts
+++ b/src/app/page-task-add.component.spec.ts
@@ -1,7 +1,9 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatDatepickerModule } from '@angular/material';
+import { MatDatepickerModule, MatInputModule, MatSliderModule } from '@angular/material';
 import { MatMomentDateModule } from '@angular/material-moment-adapter';
+import { FormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { PageTaskAddComponent } from './page-task-add.component';
 
@@ -13,7 +15,7 @@ describe('PageTaskAddComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ PageTaskAddComponent ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
-      imports: [ MatDatepickerModule, MatMomentDateModule ],
+      imports: [ MatDatepickerModule, MatMomentDateModule, FormsModule, MatInputModule, MatSliderModule, BrowserAnimationsModule ],
     })
     .compileComponents();
   }));

--- a/src/app/page-task-add.component.ts
+++ b/src/app/page-task-add.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { MatDatepicker } from '@angular/material/datepicker';
+import { Task } from './task';
+import uuid from 'uuid';
 
 @Component({
   selector: 'app-page-task-add',
@@ -7,6 +8,13 @@ import { MatDatepicker } from '@angular/material/datepicker';
   styleUrls: ['./page-task-add.component.scss']
 })
 export class PageTaskAddComponent implements OnInit {
+  deadline: Date;
+  task: Task = {
+    id: uuid(),
+    name: '',
+    deadline: new Date(),
+    estimate: 1,
+  };
 
   constructor() { }
 

--- a/src/app/page-task-add.component.ts
+++ b/src/app/page-task-add.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { MatDatepicker } from '@angular/material/datepicker';
 
 @Component({
   selector: 'app-page-task-add',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7656,7 +7656,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.0.0, uuid@^3.0.1, uuid@^3.3.2:
+uuid@^3.0.0, uuid@^3.0.1, uuid@^3.3.2, uuid@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,6 +202,13 @@
   resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-8.2.9.tgz#b20c938bad93c046a22bbe44dd4fecd1ff039ff0"
   integrity sha512-F6ReN0cToHIkCjEM2ECkBxCTsvFjVae8FpIr3Fz8IHZHOOYcS5mx/BWdEO7odI5/tQKl+cCWol7NjvJYV0zolg==
 
+"@angular/material-moment-adapter@^8.2.3":
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/@angular/material-moment-adapter/-/material-moment-adapter-8.2.3.tgz#099fce64a3ffb3cfe30141700b195f5058cb360d"
+  integrity sha512-x0WE9MyQajqzGPYKm8eHcDmWWlwiobOX9rZ+V5uqY80fsvm2czk6TYnc1drFYcPAHIaIcx7je7NYOULPF1rTpw==
+  dependencies:
+    tslib "^1.7.1"
+
 "@angular/material@^8.2.3":
   version "8.2.3"
   resolved "https://registry.yarnpkg.com/@angular/material/-/material-8.2.3.tgz#16543e4e06a3fde2651a25cfe126e88e714ae105"
@@ -5067,6 +5074,11 @@ mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## What

タスクの追加コンポーネントに、各タスクに必要なデータを入力する入力コンポーネントを追加しました。

日付の選択には DatePicker を使用し、見積りの入力にはスライダーを使用しました。

## コメント

- カレンダーを開くにはアイコンを選択しなければなりません。できれば input のどこを選んでもカレンダーが表示されてほしいです。
- 「タスクを追加」ボタンは誤タップしないように一番下に配置した方がいいと思います。しかし、スペーサーが見つけられなかったので、そのままスライダーの直下に置かれています。

## 現在のスクリーンショット

<img width="444" alt="Screen Shot 2019-10-18 at 16 21 54" src="https://user-images.githubusercontent.com/1425259/67074115-6fe97b80-f1c3-11e9-91bd-4008ae973356.png">
(画面下のデバッグ用表示は無視してください)

## TODO

- まだ MatDatepicker で選択した日付がうまく変数に束縛できていません。
