### PR TITLE
CircleCI の config.yml の文法が間違っていたのを修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2
 jobs:
   build:
     branches:
-      ignore: gh-pages
+      ignore:
+        - gh-pages
     working_directory: ~/repo
     docker:
       - image: circleci/node:10-browsers


### PR DESCRIPTION
Ref. [Configuring CircleCI - CircleCI](https://circleci.com/docs/2.0/configuration-reference/#branches)