### PR TITLE
gh-pages の deploy 時に CircleCI のテストが実行されないようにする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,6 @@
 version: 2
 jobs:
   build:
-    branches:
-      ignore:
-        - gh-pages
     working_directory: ~/repo
     docker:
       - image: circleci/node:10-browsers

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "deploy": "ng deploy --base-href=/task-cabinet/"
+    "deploy": "env CIRCLECI=1 ng deploy --base-href=/task-cabinet/"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
[angular-cli-ghpages - npm](https://www.npmjs.com/package/angular-cli-ghpages#message) によると、`ng deploy` 実行時に環境変数 `CIRCLECI` が設定されているとよしなに扱ってくれるみたいです。

変更コミットがなくてまだ試せていないので、次回の deploy 時にうまく行けばマージしてください。