### PR TITLE
Datetimeのフォーマットを整形

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,8 @@ import {
 import { FormsModule } from '@angular/forms';
 import { MatMomentDateModule } from '@angular/material-moment-adapter';
 import { PageTaskAddComponent } from './page-task-add.component';
+import { MatGridListModule } from '@angular/material';
+import { DatePipe } from '@angular/common';
 
 @NgModule({
   declarations: [
@@ -45,8 +47,9 @@ import { PageTaskAddComponent } from './page-task-add.component';
     MatFormFieldModule,
     MatInputModule,
     MatSliderModule,
+    MatGridListModule,
   ],
-  providers: [],
+  providers: [DatePipe],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/page-task.component.html
+++ b/src/app/page-task.component.html
@@ -1,20 +1,22 @@
 <app-layout>
   <mat-card *ngFor="let task of taskList">
     <mat-card-title>{{task.name}}</mat-card-title>
-    <table>
-      <tbody>
-        <tr>
-          <th>期限</th>
-          <td>{{task.deadline}}</td>
-        </tr>
-        <tr>
-          <th>見積もり</th>
-          <td>
-            <mat-progress-bar [value]="task.estimate"></mat-progress-bar>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <mat-grid-list cols="4" rowHeight="2rem">
+      <mat-grid-tile [colspan]="1" [rowspan]="1" class="task-header">
+        期限
+      </mat-grid-tile>
+      <mat-grid-tile [colspan]="3" [rowspan]="1" class="task-deadline">
+        <div class="task-deadline">
+          {{ formatDatetime(task.deadline) }}
+        </div>
+      </mat-grid-tile>
+      <mat-grid-tile [colspan]="1" class="task-header">
+        見積もり
+      </mat-grid-tile>
+      <mat-grid-tile [colspan]="3" class="task-deadline">
+        <mat-progress-bar [value]="task.estimate"></mat-progress-bar>
+      </mat-grid-tile>
+    </mat-grid-list>
     <div class="done-button-wrapper">
       <button mat-button (click)="doneTask(task)">
         <mat-icon>done</mat-icon>

--- a/src/app/page-task.component.scss
+++ b/src/app/page-task.component.scss
@@ -27,3 +27,12 @@ table {
 .spacer {
   height: 5rem;
 }
+
+.task-header {
+  font-weight: bold;
+}
+
+.task-deadline {
+  position: absolute;
+  left: 1px;
+}

--- a/src/app/page-task.component.spec.ts
+++ b/src/app/page-task.component.spec.ts
@@ -2,6 +2,7 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PageTaskComponent } from './page-task.component';
+import { DatePipe } from '@angular/common';
 
 describe('PageTaskComponent', () => {
   let component: PageTaskComponent;
@@ -11,6 +12,7 @@ describe('PageTaskComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ PageTaskComponent ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
+      providers: [ DatePipe ],
     })
     .compileComponents();
   }));

--- a/src/app/page-task.component.ts
+++ b/src/app/page-task.component.ts
@@ -36,9 +36,9 @@ export class PageTaskComponent implements OnInit {
     const dayNames = ['日', '月', '火', '水', '木', '金', '土'];
     const qDayName = dayNames[q.getDay()];
     if (q.getFullYear() === now.getFullYear()) {
-      return  this.datePipe.transform(q, 'M月d日 HH:mm') + ` (${qDayName})`;
+      return  this.datePipe.transform(q, `M月d日(${qDayName}) HH:mm`);
     } else {
-      return  this.datePipe.transform(q, 'yyyy年M月d日 HH:mm') + ` (${qDayName})`;
+      return  this.datePipe.transform(q, `yyyy年M月d日(${qDayName}) HH:mm`);
     }
   }
 }

--- a/src/app/page-task.component.ts
+++ b/src/app/page-task.component.ts
@@ -33,10 +33,12 @@ export class PageTaskComponent implements OnInit {
   formatDatetime(datetime: Date) {
     const q = new Date(datetime);
     const now = new Date();
-    if (q.getUTCFullYear() === now.getUTCFullYear()) {
-      return  this.datePipe.transform(q, 'M月d日 HH:mm');
+    const dayNames = ['日', '月', '火', '水', '木', '金', '土'];
+    const qDayName = dayNames[q.getDay()];
+    if (q.getFullYear() === now.getFullYear()) {
+      return  this.datePipe.transform(q, 'M月d日 HH:mm') + ` (${qDayName})`;
     } else {
-      return  this.datePipe.transform(q, 'yyyy年M月d日 HH:mm');
+      return  this.datePipe.transform(q, 'yyyy年M月d日 HH:mm') + ` (${qDayName})`;
     }
   }
 }

--- a/src/app/page-task.component.ts
+++ b/src/app/page-task.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Task } from './task';
 import { TaskService } from './task.service';
+import { DatePipe } from '@angular/common';
 
 @Component({
   selector: 'app-page-task',
@@ -11,7 +12,7 @@ export class PageTaskComponent implements OnInit {
 
   taskList: Task[] = [];
 
-  constructor(private taskService: TaskService) { }
+  constructor(private taskService: TaskService, private datePipe: DatePipe) { }
 
   ngOnInit() {
     this.updateTaskList();
@@ -27,5 +28,15 @@ export class PageTaskComponent implements OnInit {
     this.taskService.getTaskListOrderByAsap().subscribe((taskList) => {
       this.taskList = taskList;
     });
+  }
+
+  formatDatetime(datetime: Date) {
+    const q = new Date(datetime);
+    const now = new Date();
+    if (q.getUTCFullYear() === now.getUTCFullYear()) {
+      return  this.datePipe.transform(q, 'M月d日 HH:mm');
+    } else {
+      return  this.datePipe.transform(q, 'yyyy年M月d日 HH:mm');
+    }
   }
 }


### PR DESCRIPTION
- [x] Datetimeのフォーマットを整形
- [x] タスクのカードをグリッド化

年内の期限に関しては月から表示して、今年以外の期限に関しては年から表示しています。
アプリ起動時が2019年の場合：2019/8/1 => 8月1日, 2020/1/2 => 2020年1月2日

![Screen Shot 2019-10-25 at 22 06 21](https://user-images.githubusercontent.com/28585609/67573605-b61a7e00-f773-11e9-8402-4bf8fa858bd9.png)

close #51 