### PR TITLE
通知のON/OFFをサーバーとつなぎ合わせる

### DIFF
--- a/src/app/models/device.spec.ts
+++ b/src/app/models/device.spec.ts
@@ -1,0 +1,2 @@
+describe('Device', () => {
+});

--- a/src/app/models/device.ts
+++ b/src/app/models/device.ts
@@ -1,0 +1,14 @@
+class Key {
+  constructor(
+    public auth: string,
+    public p256dh: string
+  ) { }
+}
+
+
+export class Device {
+  constructor(
+    public endpoint: string,
+    public keys: Key,
+  ) { }
+}

--- a/src/app/page-task.component.spec.ts
+++ b/src/app/page-task.component.spec.ts
@@ -6,6 +6,12 @@ import { DatePipe } from '@angular/common';
 import { TaskService } from './task.service';
 import { of } from 'rxjs';
 import { Task } from './task';
+import { ServiceWorkerModule, SwPush } from '@angular/service-worker';
+import { DeviceService } from './services/device.service';
+import { environment } from '../environments/environment';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { CookieService } from 'ngx-cookie-service';
+import { AlertService } from './services/alert.service';
 
 describe('PageTaskComponent', () => {
   let component: PageTaskComponent;
@@ -17,6 +23,10 @@ describe('PageTaskComponent', () => {
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
       providers: [
         DatePipe,
+        DeviceService,
+        SwPush,
+        CookieService,
+        AlertService,
         {
           provide: TaskService,
           useValue: {
@@ -25,8 +35,12 @@ describe('PageTaskComponent', () => {
           },
         },
       ],
+      imports: [
+        ServiceWorkerModule.register('ngsw-worker.js', { enabled: environment.production }),
+        HttpClientTestingModule
+      ],
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/page-task.component.ts
+++ b/src/app/page-task.component.ts
@@ -24,7 +24,14 @@ export class PageTaskComponent implements OnInit {
 
   ngOnInit() {
     this.updateTaskList();
-    this.isSubscribing = false;
+    this.deviceService.checkIsSubscribing().subscribe(
+      isSub => {
+        this.isSubscribing = isSub;
+      }, err => {
+        console.error(err);
+        this.isSubscribing = false;
+      }
+    );
   }
 
   onSubscribe() {

--- a/src/app/page-task.component.ts
+++ b/src/app/page-task.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { Task } from './task';
 import { TaskService } from './task.service';
 import { DatePipe } from '@angular/common';
+import { DeviceService } from './services/device.service';
+import { AlertService } from './services/alert.service';
 
 @Component({
   selector: 'app-page-task',
@@ -13,7 +15,12 @@ export class PageTaskComponent implements OnInit {
   taskList: Task[] = [];
   isSubscribing: boolean;
 
-  constructor(private taskService: TaskService, private datePipe: DatePipe) { }
+  constructor(
+    private taskService: TaskService,
+    private datePipe: DatePipe,
+    private deviceService: DeviceService,
+    public alertService: AlertService
+  ) { }
 
   ngOnInit() {
     this.updateTaskList();
@@ -21,11 +28,23 @@ export class PageTaskComponent implements OnInit {
   }
 
   onSubscribe() {
-    this.isSubscribing = true;
+    this.deviceService.subscribePush().subscribe(
+      () => {
+        this.isSubscribing = true;
+        this.alertService.showSuccessAlert('通知をONに設定しました。');
+      }, err => {
+        this.alertService.showErrorAlert('通知の設定に失敗しました。');
+      });
   }
 
   onUnsubscribe() {
-    this.isSubscribing = false;
+    this.deviceService.unSubscribePush().subscribe(
+      () => {
+        this.isSubscribing = false;
+        this.alertService.showSuccessAlert('通知をOFFに設定しました。');
+      }, err => {
+        this.alertService.showErrorAlert('通知の設定に失敗しました。');
+      });
   }
 
   doneTask(task: Task) {

--- a/src/app/services/device.service.spec.ts
+++ b/src/app/services/device.service.spec.ts
@@ -1,0 +1,22 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DeviceService } from './device.service';
+import { ServiceWorkerModule, SwPush } from '@angular/service-worker';
+import { environment } from '../../environments/environment';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { CookieService } from 'ngx-cookie-service';
+
+describe('DeviceService', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    providers: [SwPush, CookieService],
+    imports: [
+      HttpClientTestingModule,
+      ServiceWorkerModule.register('ngsw-worker.js', { enabled: environment.production }),
+    ],
+  }));
+
+  it('should be created', () => {
+    const service: DeviceService = TestBed.get(DeviceService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/device.service.ts
+++ b/src/app/services/device.service.ts
@@ -70,6 +70,30 @@ export class DeviceService {
     }));
   }
 
+  checkIsSubscribing(): Observable<boolean> {
+    return new Observable((observer => {
+      this.getKey()
+        .then(device => {
+          this.http.post(`${environment.apiUrl}/tcs/users/${this.authService.getUserId()}/check-device`, device, {
+            headers: new HttpHeaders({
+              Authorization: this.authService.getAuthHeader(),
+              'Content-Type': 'application/json',
+            }),
+          }).subscribe((response: any) => {
+            if (response.result === undefined) {
+              observer.error(new Error('Fail to post device information'));
+            }
+            console.log(response);
+            observer.next(response.result.is_exist === 1);
+          }, err => {
+            observer.error(err);
+          });
+        }).catch(err => {
+        observer.error(err);
+      });
+    }));
+  }
+
   getKey(): Promise<Device> {
     return this.swPush.requestSubscription({serverPublicKey: environment.vapIdPublicKey})
       .then(sub => {

--- a/src/app/services/device.service.ts
+++ b/src/app/services/device.service.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@angular/core';
+import { environment } from '../../environments/environment';
+import { SwPush } from '@angular/service-worker';
+import { Device } from '../models/device';
+import { Observable } from 'rxjs';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { AuthService } from './auth.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DeviceService {
+
+  constructor(private swPush: SwPush, private http: HttpClient, private authService: AuthService) {
+  }
+
+  private static arrayBufferToBase64(arrayBuffer): string {
+    const binary = String.fromCharCode.apply(null, new Uint8Array(arrayBuffer));
+    return window.btoa(binary).replace(/\+/g, '-').replace(/\//g, '_');
+  }
+
+  subscribePush(): Observable<Device> {
+    return new Observable((observer => {
+      this.getKey()
+        .then(device => {
+          this.http.post(`${environment.apiUrl}/tcs/users/${this.authService.getUserId()}/device`, device, {
+            headers: new HttpHeaders({
+              Authorization: this.authService.getAuthHeader(),
+              'Content-Type': 'application/json',
+            }),
+          }).subscribe((response: any) => {
+            if (response.result === undefined) {
+              observer.error(new Error('Fail to post device information'));
+            }
+            observer.next(response.result);
+          }, err => {
+            if (err.status === 409) {  // ConflictなのでOKとする
+              return observer.next(device);
+            }
+            observer.error(err);
+          });
+        }).catch(err => {
+        observer.error(err);
+      });
+    }));
+  }
+
+  unSubscribePush(): Observable<void> {
+    return new Observable((observer => {
+      this.getKey()
+        .then(device => {
+          this.http.request('delete', `${environment.apiUrl}/tcs/users/${this.authService.getUserId()}/device`, {
+            headers: new HttpHeaders({
+              Authorization: this.authService.getAuthHeader(),
+              'Content-Type': 'application/json',
+            }),
+            body: device,
+            observe: 'response'  // For get status
+          }).subscribe((response: any) => {
+            if (response.status !== 200) {
+              return observer.error(new Error('Fail to Delete device information.'));
+            }
+            observer.next();
+          }, err => {
+            observer.error(err);
+          });
+        }).catch(err => {
+        observer.error(err);
+      });
+    }));
+  }
+
+  getKey(): Promise<Device> {
+    return this.swPush.requestSubscription({serverPublicKey: environment.vapIdPublicKey})
+      .then(sub => {
+        return {
+          endpoint: sub.endpoint,
+          keys: {
+            auth: DeviceService.arrayBufferToBase64(sub.getKey('auth')),
+            p256dh: DeviceService.arrayBufferToBase64(sub.getKey('p256dh'))
+          }
+        };
+      })
+      .catch(err => {
+        throw err;
+      });
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   apiUrl: 'https://www.tcs-service.megurumokke.org',
-  vapIdPublicKey: 'YourSecretKey' // TODO: 機密情報の扱い
+  vapIdPublicKey: 'BKC5-9mK29h2-ryo14BqYqppcN0HtDwFyNZLfmiMvumImyC3sKaWAt_gabaY_u-ffxC2uUDeJcmlBgDpHuo6FBE='
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  apiUrl: 'http://104.197.246.60:3000'
+  apiUrl: 'https://www.tcs-service.megurumokke.org',
+  vapIdPublicKey: 'YourSecretKey' // TODO: 機密情報の扱い
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,8 @@
 
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:4200'  // Proxyでサーバーに転送する(CORS対策)
+  apiUrl: 'http://localhost:4200',  // Proxyでサーバーに転送する(CORS対策)
+  vapIdPublicKey: 'YourSecretKey' // TODO: 機密情報の扱い
 };
 
 /*

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,7 +5,7 @@
 export const environment = {
   production: false,
   apiUrl: 'http://localhost:4200',  // Proxyでサーバーに転送する(CORS対策)
-  vapIdPublicKey: 'YourSecretKey' // TODO: 機密情報の扱い
+  vapIdPublicKey: 'BKC5-9mK29h2-ryo14BqYqppcN0HtDwFyNZLfmiMvumImyC3sKaWAt_gabaY_u-ffxC2uUDeJcmlBgDpHuo6FBE='
 };
 
 /*


### PR DESCRIPTION
# タスク
- [x] クライアント情報の取得
- [x] クライアント情報をDBに保存
- [x] 通知ボタンの状態をDBと連携する
- [x] public_keyの保存方法の検討
  - vapIdPublicKeyをどう保存するか
  - dotenvはAngularでは使えないっぽい
  - ~~各々環境変数で対応? or `enviroment.ts`等をgitignoreする?~~
    - 今回は公開鍵だけなのでハードコーディングする
```
export const environment = {
  production: true,
  apiUrl: 'https://www.tcs-service.megurumokke.org',
  vapIdPublicKey: 'YourSecretKey' // TODO: 機密情報の扱い
};
```

# ローカルでの検証方法
CROSSやServiceWorkerがからむため、現状は結合テストは行えないので、機能単位で検証を行う
## クライアント情報取得
ServiceWorkerを使うので、ビルドを行う
- consoleでクライアント情報を表示
  - 仮でデバッグを行う
  - `page-task.component.ts`の31行目に以下のコードを追加
```
31 + this.deviceService.getKey().then(device => {
32 +       console.info(device);
33 + });
```
- ビルド & サーバー立ち上げ
```
$ ng build --prod
$ http-server -p 8080 -c-1 dist/task-cabinet
$ open http://localhost:8080
```
- ログイン後、通知ボタンを押下するとコンソールにクライアント情報が表示されていることを確認する

## サーバーに情報を送信
Proxyを使うため、`ng serve --proxy-config src/proxy.conf.json`で立ち上げる(=ServiceWorkerは使えない)

クライアント情報を取得する部分は上記の手順で取得し、ハードコーディングして検証をする
- `device.service.ts`の`getKey`メソッドを置き換える
```
getKey(): Promise<Device> {
    return new Promise<Device>(
      resolve => {
        resolve(
          {
            endpoint: 'Your_endpoint',
            keys: {
              auth: 'Your_auth',
              p256dh: 'Your_p256dh'
            }
          });
      }
    )
  }
```
- サーバー立ち上げ
```
$ ng serve --proxy-config src/proxy.conf.json
```

- ログイン後通知ボタンを押下して、DBにクライアント情報が追加されているか確認する