### PR TITLE
アクセス時にクエリパラメータからアルゴリズムタイプをサーバーにpost

### DIFF
--- a/src/app/layout.component.spec.ts
+++ b/src/app/layout.component.spec.ts
@@ -6,6 +6,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { CookieService } from 'ngx-cookie-service';
 import { AlertService } from './services/alert.service';
+import { ServiceWorkerModule, SwPush } from '@angular/service-worker';
+import { environment } from '../environments/environment';
 
 describe('LayoutComponent', () => {
   let component: LayoutComponent;
@@ -14,9 +16,12 @@ describe('LayoutComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ LayoutComponent ],
-      imports: [ RouterTestingModule, HttpClientTestingModule ],
+      imports: [
+        RouterTestingModule,
+        HttpClientTestingModule,
+        ServiceWorkerModule.register('ngsw-worker.js', { enabled: environment.production })],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
-      providers: [ CookieService, AlertService ]
+      providers: [ CookieService, AlertService, SwPush ]
     })
     .compileComponents();
   }));

--- a/src/app/layout.component.ts
+++ b/src/app/layout.component.ts
@@ -22,13 +22,13 @@ export class LayoutComponent implements OnInit {
     this.alertService.hideAlert();
     this.route.queryParams.subscribe(
       params => {
-        pushType = parseInt(params.pushType);
+        pushType = parseInt(params.pushType, 10);
       }
     );
     if (pushType && this.isLoggedIn) {
       this.deviceService.postPushType(pushType).subscribe(res => {
         if (!res) {
-          console.error("Fail to post pushType");
+          console.error('Fail to post pushType');
         }
       }, err => {
         console.error(err);

--- a/src/app/layout.component.ts
+++ b/src/app/layout.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { AuthService } from './services/auth.service';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { AlertService } from './services/alert.service';
+import { DeviceService } from './services/device.service';
 
 @Component({
   selector: 'app-layout',
@@ -10,10 +11,29 @@ import { AlertService } from './services/alert.service';
 })
 export class LayoutComponent implements OnInit {
 
-  constructor(private router: Router, private authService: AuthService, private alertService: AlertService) { }
+  constructor(private route: ActivatedRoute,
+              private router: Router,
+              private authService: AuthService,
+              private alertService: AlertService,
+              private deviceService: DeviceService) { }
 
   ngOnInit() {
+    let pushType: number = null;
     this.alertService.hideAlert();
+    this.route.queryParams.subscribe(
+      params => {
+        pushType = parseInt(params.pushType);
+      }
+    );
+    if (pushType) {
+      this.deviceService.postPushType(pushType).subscribe(res => {
+        if (!res) {
+          console.error("Fail to post pushType");
+        }
+      }, err => {
+        console.error(err);
+      });
+    }
   }
 
   isLoggedIn(): boolean {

--- a/src/app/layout.component.ts
+++ b/src/app/layout.component.ts
@@ -25,7 +25,7 @@ export class LayoutComponent implements OnInit {
         pushType = parseInt(params.pushType);
       }
     );
-    if (pushType) {
+    if (pushType && this.isLoggedIn) {
       this.deviceService.postPushType(pushType).subscribe(res => {
         if (!res) {
           console.error("Fail to post pushType");

--- a/src/app/services/device.service.ts
+++ b/src/app/services/device.service.ts
@@ -116,7 +116,7 @@ export class DeviceService {
 
   postPushType(type: number): Observable<boolean> {
     return this.http.post(`${environment.apiUrl}/tcs/users/${this.authService.getUserId()}/algorithm`, {
-      type: type
+      type
     }, {
       headers: new HttpHeaders({
         Authorization: this.authService.getAuthHeader(),

--- a/src/app/services/device.service.ts
+++ b/src/app/services/device.service.ts
@@ -3,6 +3,7 @@ import { environment } from '../../environments/environment';
 import { SwPush } from '@angular/service-worker';
 import { Device } from '../models/device';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { AuthService } from './auth.service';
 
@@ -111,5 +112,22 @@ export class DeviceService {
       .catch(err => {
         throw err;
       });
+  }
+
+  postPushType(type: number): Observable<boolean> {
+    return this.http.post(`${environment.apiUrl}/tcs/users/${this.authService.getUserId()}/algorithm`, {
+      type: type
+    }, {
+      headers: new HttpHeaders({
+        Authorization: this.authService.getAuthHeader(),
+        'Content-Type': 'application/json',
+      }),
+      withCredentials: true
+    }).pipe(map((response: any): boolean => {
+      if (response.result === undefined) {
+        throw new Error('fail to post pushType.');
+      }
+      return true;
+    }));
   }
 }


### PR DESCRIPTION
アクセス時にクエリパラメータに付いているpushTypeをサーバーに送ります。
(ログイン時の)どのページでも動作します。

プッシュ通知をクリックされた時にどうやってTaskCabinetに飛ばすかは #116 で対応

ex) `/task?pushType=1`