### PR TITLE
user token, user id がセッションの有効期限で切れないように、 30 日に変更

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -23,8 +23,9 @@ export class AuthService {
       .toPromise()
       .then((result: any) => {
         if (result.result !== undefined && result.result.token !== undefined) {
-          this.cookieService.set('user_token', result.result.token);
-          this.cookieService.set('user_id', result.result.id);
+          // 30 days
+          this.cookieService.set('user_token', result.result.token, 30);
+          this.cookieService.set('user_id', result.result.id, 30);
           return result.result;
         } else {
           return null;


### PR DESCRIPTION
cookie の有効期限が session だと、 セッションが切れたときに自動的に削除され、結果ログアウトと同じ状態になっています（セッションが持続しない）。
それを、 cookie の有効期限を 30 日に変更して、ある程度ログイン状態を維持できるようにしました。