### PR TITLE
未認証専用ページに認済み時にアクセスしたときに /task にリダイレクト

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,15 +6,16 @@ import { PageTopComponent } from './page-top.component';
 import { PageSignInComponent } from './page-sign-in.component';
 import { PageCreateUserComponent } from './page-create-user.component';
 import { AuthGuard } from './guards/auth.guard';
+import { UnAuthGuard } from './guards/un-auth.guard';
 
 
 const routes: Routes = [
   { path: 'task', component: PageTaskComponent, canActivate: [AuthGuard] },
   { path: 'add', component: PageTaskEditComponent, canActivate: [AuthGuard] },
   { path: 'edit/:id', component: PageTaskEditComponent, canActivate: [AuthGuard] },
-  { path: '', component: PageTopComponent },
-  { path: 'sign-in', component: PageSignInComponent },
-  { path: 'sign-up', component: PageCreateUserComponent },
+  { path: '', component: PageTopComponent, canActivate: [UnAuthGuard] },
+  { path: 'sign-in', component: PageSignInComponent, canActivate: [UnAuthGuard] },
+  { path: 'sign-up', component: PageCreateUserComponent, canActivate: [UnAuthGuard] },
 ];
 
 @NgModule({

--- a/src/app/guards/un-auth.guard.spec.ts
+++ b/src/app/guards/un-auth.guard.spec.ts
@@ -1,0 +1,19 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { AuthGuard } from './auth.guard';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { CookieService } from 'ngx-cookie-service';
+
+describe('UnAuthGuard', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AuthGuard, CookieService],
+      imports: [RouterTestingModule, HttpClientTestingModule]
+    });
+  });
+
+  it('should ...', inject([AuthGuard], (guard: AuthGuard) => {
+    expect(guard).toBeTruthy();
+  }));
+});

--- a/src/app/guards/un-auth.guard.ts
+++ b/src/app/guards/un-auth.guard.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree, Router } from '@angular/router';
+import { Observable } from 'rxjs';
+import { AuthService } from '../services/auth.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UnAuthGuard implements CanActivate {
+  constructor(private router: Router,  private authService: AuthService) {}
+
+  canActivate(
+    next: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    if (this.authService.isLogin()) {
+      this.router.navigate(['task']);
+      return false;
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
認証済みのときに /, /sign-in, /sign-up にアクセスしたときにそのまま表示されるのは望ましくないので、 /task にリダイレクトするようにしました。